### PR TITLE
SOM-61: Add created_on field

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,0 +1,2 @@
+Greg @yro
+Ari @arizzitano

--- a/README.md
+++ b/README.md
@@ -2,7 +2,12 @@
 City of Somerville's Somerstat Dashboard pipeline code.
 
 ## Intro
-This code hits several endpoints based on clients built to the API specs, grooms and deidentifies data to city spec, and uploads the groomed data into Socrata (and other) endpoints.
+This code hits several endpoints based on clients built to the API specs, grooms and deidentifies data to city spec, and uploads the groomed data into prepared Socrata endpoints.
+
+This is the companion repo to the [stat_dashboard_frontend](https://github.com/cityofsomerville/stat_dashboard_frontend)
+
+## Issues
+Please file found bugs or other issues here in the github repo, it's maintained and monitored. Would you like to contribute a fix? Please do!
 
 ## Install
 <!-- NOTE: This may be replaced by a pypi package, TBD. -->

--- a/stat_dashboard_pipeline/__init__.py
+++ b/stat_dashboard_pipeline/__init__.py
@@ -79,12 +79,14 @@ class Pipeline():
             "[PIPELINE] Migrate: %s",
             datetime.datetime.now().strftime("%Y-%m-%d %H:%M")
         )
+        self.qscend = QScendPipeline(
+            time_window=MIGRATION_UPDATE_WINDOW
+        )
         self.__prepare()
         # QScend
-        self.qscend.time_window = MIGRATION_UPDATE_WINDOW
         self.qscend.run()
         self.citizenserve.run()
-        self.migrate_qscend()
+        self.dump_to_csv()
 
     def store_citizenserve(self):
         # Upsert Citizenserve Permit Data
@@ -120,7 +122,7 @@ class Pipeline():
         logging.info('[SOCRATA] Storing QSCend Types')
         socrata.run()
 
-    def migrate_qscend(self):
+    def dump_to_csv(self):
         """
         This is an initial 'create CSV' method for migrating
         large datasets and instantiating them in the Socrata UI

--- a/stat_dashboard_pipeline/pipeline/qscend.py
+++ b/stat_dashboard_pipeline/pipeline/qscend.py
@@ -111,6 +111,13 @@ class QScendPipeline():
         """
         raw_activities = self.raw['activity']
         for activity in raw_activities:
+            request_id = activity['requestId']
+            # Ditch `isPrivate` request IDs
+            try:
+                self.requests[request_id]
+            except KeyError:
+                continue
+
             # Convert to datetime
             action_date = self.get_date(activity['displayDate'])
             activity['action_date'] = action_date
@@ -123,8 +130,18 @@ class QScendPipeline():
                 if route.strip() and route.strip()[0].isupper():
                     activity['route'].append(route.strip())
 
+            # Find first action_date
+            # Set created_on in self.requests column
+            try:
+                self.requests[request_id]['created_on']
+            except KeyError:
+                self.requests[request_id]['created_on'] = action_date
+            else:
+                if self.requests[request_id]['created_on'] > action_date:
+                    self.requests[request_id]['created_on'] = action_date
+
             self.activities[activity['id']] = {
-                'request_id': activity['requestId'],
+                'request_id': request_id,
                 'action_date': activity['action_date'],
                 'code': activity['code'],
                 'codeDesc': activity['codeDesc'],

--- a/stat_dashboard_pipeline/tests/pipeline/test_qscend.py
+++ b/stat_dashboard_pipeline/tests/pipeline/test_qscend.py
@@ -111,23 +111,38 @@ class CitizenServeClientTest(unittest.TestCase):
 
     @freeze_time("2012-01-14 16:30")
     @ddt.data([
-        {'activity': [
-            {
+        {
+            'activity': [{
                 'id': 1,
                 'routeId': 'yro, TestHarness, DPW',
                 'displayDate': '1/14/2012 4:30 PM',
                 'requestId': 2,
                 'code': 15,
                 'codeDesc': 'Test'
+            }]
+        },
+        {
+            2: {
+                'typeId': 350,
+                'displayLastAction': '1/14/2012 4:30 PM',
+                'dept': 'Parking',
+                'latitude': 0,
+                'longitude': 0,
+                'status': 1,
+                'origin': 'Test Harness',
+                'comment': 'PII',
+                'reporter': 'PII'
             }
-        ]}
+        }
     ])
     @ddt.unpack
-    def test_groom_activities(self, raw_data):
+    def test_groom_activities(self, raw_data, groomed_requests):
         self.qscend.raw = raw_data
+        self.qscend.requests = groomed_requests
         self.qscend.groom_activities()
 
         activity = self.qscend.activities[1]
+
         self.assertEqual(activity['request_id'], 2)
         self.assertEqual(activity['codeDesc'], 'Test')
         self.assertEqual(activity['route'], "['TestHarness', 'DPW']")


### PR DESCRIPTION
# SomerStat Dashboard Data Pipeline

### Note: 
 - Add `created_on` field to Requests table
 - Cleanout orphan `activities` (no FK to `request`, either orphan or `isPrivate: true` type)

### Checklist:
 - [x] README Updated

#### Review: @arizzitano 

#### FYI: @mmastrobuoni 
