### PR TITLE
Add columns to CS pipeline, cleanup init

### DIFF
--- a/config/sample_auth.yaml
+++ b/config/sample_auth.yaml
@@ -18,3 +18,6 @@ socrata_username: ''
 socrata_password: ''
 socrata_token: ''
 socrata_url: ''
+
+# Google Analytics
+ga_view_id: ''

--- a/stat_dashboard_pipeline/pipeline/citizenserve.py
+++ b/stat_dashboard_pipeline/pipeline/citizenserve.py
@@ -46,7 +46,9 @@ class CitizenServePipeline(CitizenServeClient):
                         'status': row['Status'],
                         'amount': row['PermitAmount'],
                         'latitude': row['Latitude'],
-                        'longitude': row['Longitude']
+                        'longitude': row['Longitude'],
+                        'address': self.groom_address(row['Address']),
+                        'work': self.groom_work_field(row['ProjectName'])
                     }
 
     def determine_update_window(self, date):
@@ -89,3 +91,15 @@ class CitizenServePipeline(CitizenServeClient):
         """
         config = Config()
         return config.permit_categories
+
+    @staticmethod
+    def groom_work_field(raw_work):
+        return ' '.join(
+            raw_work.split()
+        ).replace(',', '').capitalize().strip()
+
+    @staticmethod
+    def groom_address(raw_addy):
+        return ' '.join(
+            raw_addy.split()
+        ).strip().title()

--- a/stat_dashboard_pipeline/tests/pipeline/test_citizenserve.py
+++ b/stat_dashboard_pipeline/tests/pipeline/test_citizenserve.py
@@ -48,7 +48,9 @@ class CitizenServePipelineTest(unittest.TestCase):
         'Status': "Issued",
         'PermitAmount': 278.00,
         'Latitude': 0,
-        'Longitude': 0
+        'Longitude': 0,
+        'Address': '93  HIGHLAND   ave',
+        'ProjectName': 'REPLACE   SOMERSTAT DaTa DASHBOARD'
     }])
     @ddt.unpack
     def test_groom_permits(self, permit_data):
@@ -96,6 +98,17 @@ class CitizenServePipelineTest(unittest.TestCase):
             permit_dict['application_date'],
             application_date
         )
+        # Tests grooming as well
+        self.assertEqual(
+            permit_dict['work'],
+            'Replace somerstat data dashboard'
+        )
+        self.assertEqual(
+            permit_dict['address'],
+            '93 Highland Ave'
+        )
+
+
 
     @ddt.data([
         {


### PR DESCRIPTION
# SomerStat Dashboard Data Pipeline

### Note: 
 - Add `work` and `address` columns to permits pipeline
 - Cleanup `init` method from CLI

### Checklist:
 - [ ] README Updated

#### Review: @arizzitano 

#### FYI: @mmastrobuoni 
